### PR TITLE
Fixed Timer overflow bug

### DIFF
--- a/src/include/lwip/def.h
+++ b/src/include/lwip/def.h
@@ -115,6 +115,10 @@ u32_t lwip_ntohl(u32_t x);
 
 #endif /* BYTE_ORDER == BIG_ENDIAN */
 
+/** Get the absolute difference between 2 u32_t values (correcting overflows)
+ * 'a' is expected to be 'higher' (without overflow) than 'b'. */
+#define LWIP_U32_DIFF(a, b) (((a) >= (b)) ? ((a) - (b)) : (((a) + ((b) ^ 0xFFFFFFFF) + 1)))
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
When enabled flag "system_timer_reinit()" ESP will reboot by WDT timer after ~15 minutes.
This code from original espressif LWIP and it resolve reboot problem. Tested on real hardware.
